### PR TITLE
Should add the write permission to vault

### DIFF
--- a/HighAvailabilityEncodingStreaming/README.md
+++ b/HighAvailabilityEncodingStreaming/README.md
@@ -99,7 +99,7 @@ Update the Key Vault configuration to grant access to user submitting test reque
 1. Open the Key Vault instance.
 1. Go to **access policies**.
 1. Click on **Add access policy**.
-1. Select the *Get* and *List* secret permissions.
+1. Select the *Get* and *List* and *Write* secret permissions.
 1. Select **user** in the select principal dialog.
 1. Click **Add** to add access the policy.
 1. Click **Save** to save the change in Access Policies.


### PR DESCRIPTION
Because of E2ETestConfigService.cs

await keyVaultClient.SetSecretAsync($"https://{this.keyVaultName}.vault.azure.net", "ClearKeyStreamingKey", Convert.ToBase64String(this.clearKeyStreamingKey)).ConfigureAwait(false);

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Prevent exception  on test launch

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->